### PR TITLE
Left drive bugfix

### DIFF
--- a/motor_driver.py
+++ b/motor_driver.py
@@ -74,7 +74,7 @@ async def drive_to_next_tile(base, current_point: tuple, new_coordinate_pt: tupl
 
 async def main():
     # TODO: see if this can dynamically be mapped to grid cell after SLAM localization
-    start_point = (4,4)
+    start_point = (4,0)
 
     goal_point = input("Enter the goal point as x y: ")
     goal_point = goal_point.split()

--- a/motor_driver.py
+++ b/motor_driver.py
@@ -74,7 +74,7 @@ async def drive_to_next_tile(base, current_point: tuple, new_coordinate_pt: tupl
 
 async def main():
     # TODO: see if this can dynamically be mapped to grid cell after SLAM localization
-    start_point = (4,0)
+    start_point = (4,4)
 
     goal_point = input("Enter the goal point as x y: ")
     goal_point = goal_point.split()

--- a/motor_driver.py
+++ b/motor_driver.py
@@ -61,7 +61,7 @@ async def drive_to_next_tile(base, current_point: tuple, new_coordinate_pt: tupl
         await move_forward_1_foot(base)
 
     # drive to left tile
-    elif new_coordinate_pt[0] == current_point[0] - 1:
+    elif new_coordinate_pt[1] == current_point[1] - 1:
         await drive_left_1_foot(base)
 
     # drive to right tile


### PR DESCRIPTION
Needed to show that rover can drive to different goal points when varying starting point. As such, this index change corrects issue when the rover's starting point was at the right side of the enclosure and goal point was at the top left corner.
https://drive.google.com/file/d/1NJ0mMGZpQrzGmCDYBu_MC16pwKuN2QI8/view?usp=share_link